### PR TITLE
join helpers

### DIFF
--- a/Prime/Prime/String.fs
+++ b/Prime/Prime/String.fs
@@ -72,7 +72,13 @@ module String =
         let sb = StringBuilder ()
         List.iter (fun (chr : char) -> sb.Append chr |> ignore) chars
         sb.ToString ()
-
+        
+    let join delim strings =
+        List.fold (fun res str -> res + delim + str) String.Empty strings
+    
+    let joinWithChar (delim: char) strings =
+        join (string delim) strings
+        
     /// Capitalize a string.
     let capitalize (str : string) =
         match str.ToCharArray () |> List.ofArray with


### PR DESCRIPTION
Why Primitive library have explode, but do not have a basic join function?