### PR TITLE
Decode URL-encoded chars in Path.Simplify

### DIFF
--- a/Prime/Prime/Operators.fs
+++ b/Prime/Prime/Operators.fs
@@ -213,4 +213,4 @@ open System
 module Path =
 
     /// Simplify a path.
-    let Simplify (path : string) = Uri(Uri("http://example.com/"), path).AbsolutePath.TrimStart('/')
+    let Simplify (path : string) = Uri(Uri("http://example.com/"), path).AbsolutePath.TrimStart('/') |> Uri.UnescapeDataString


### PR DESCRIPTION
By using `Uri` to do its dirty work, the current implementation of Path.Simplify leaves the path URL-encoded. This breaks project creation in Nu, which cannot find a project path with spaces because they have all been replaced with `%20`.